### PR TITLE
perf: record k=10 TI Heisenberg campaign evidence and unresolved gap

### DIFF
--- a/perf/2604_01555_heisenberg_gap.md
+++ b/perf/2604_01555_heisenberg_gap.md
@@ -247,3 +247,59 @@ numerical stalling rather than model weakness.  A diagnostic rerun with 64
 threads, tolerances relaxed to `1e-7`, and Mosek logging enabled is used to
 distinguish the two; the harness exposes the tolerance through
 `NCTS_MOSEK_TOL` (default `1e-8`).
+
+## 2026-08-14: k=10 gap campaign conclusion — model weakness, not stalling
+
+The "numerical stalling" hypothesis above is **corrected** by the captured
+Mosek iteration logs (enabled by `NCTS_MOSEK_LOG=1` after PR #376).  Three
+logged runs on `6xa800` settle the question.  All used the moment-LMI form,
+`N=100`, `rdm=10`, `linear_psd` state optimality, axis symmetry, 32 Mosek
+threads, and `1e-8` tolerances.
+
+**Run 1 — separation-5 PSD basis (the paper configuration).**
+Log: `perf/results/ti_k10_mosek_log_tol1e-8.txt`.  Mosek reached
+`MU = 2.5e-9` with primal and dual objectives agreeing to `3.4e-7` and
+`PFEAS ≈ 5.3e-8` before the `SLOW_PROGRESS` exit.  That is a converged
+solve for practical purposes: `-0.4432912436` per spin is this model's true
+optimum.  The residual `5.34e-5` gap to the paper's `-0.4432378` is therefore
+**model weakness**, not solver stalling.  Peak RSS 209.2 GiB, wall 3369.9 s.
+(An earlier 64-thread, `1e-7` diagnostic of the same model gave a looser
+`-0.4433098621`, consistent with the relaxed tolerance.)
+
+**Run 2 — separation-10 PSD basis (model strengthening attempt).**
+Log: `perf/results/ti_k10_range10_mosek_log.txt`.  The wider two-site words
+grow the model to 170,293 constraints with dense Newton dimension 19,130
+(`3.67e13` flops/factorization; 48,567 unique moments).  Mosek genuinely
+stalls: iterations 19–31 are frozen at `PFEAS 1.1e-6`, `DFEAS 7.6e-5`,
+`MU 1.0e-6`.  Because `DFEAS` never reaches tolerance, the reported
+"bound" `-0.4433962393` is **not a certified lower bound**; the run is
+numerically unusable.  Peak RSS 233.3 GiB, wall 4262.9 s.
+
+**Run 3 — separation-10 with `NCTS_MOSEK_SOLVE_FORM=dual`.**
+Log: `perf/results/ti_k10_range10_dualform_mosek_log.txt`.  Mosek **ignored
+the solve-form hint**: the log reports `Optimizer - solved problem: the
+primal` (Mosek solves the primal for problems containing semidefinite
+variables), and the iteration trajectory is identical to Run 2, including
+the frozen stall and the same final values.  Peak RSS 224.1 GiB, wall
+3760.3 s.  The conditioning knob has no effect on this problem class.
+
+| configuration | bound / spin | vs paper `-0.4432378` | solver state |
+|:--|--:|--:|:--|
+| paper SDP New (k=10, sep 5) | -0.4432378 | — | — |
+| k=10, sep 5 (Run 1) | -0.4432912436 | 5.34e-5 | converged (MU 2.5e-9) |
+| k=10, sep 5, 64t/1e-7 | -0.4433098621 | 7.21e-5 | relaxed tolerance |
+| k=10, sep 10 primal (Run 2) | -0.4433962393 | 1.58e-4 | stalled, uncertified |
+| k=10, sep 10 "dual" (Run 3) | -0.4433962393 | 1.58e-4 | identical stall |
+
+**Verdict: parity not achieved with existing knobs.**  The separation-5
+model converges but is structurally `5.34e-5` weaker than QMBCertify's
+published bound; the separation-10 model is too ill-conditioned for Mosek
+to solve at all.  Since the mechanisms (10-site RDM, linear commutators,
+degree-3 PSD state optimality, axis quotient) nominally match the paper,
+the discrepancy most likely lives in the exact contents of the degree-3
+PSD state-optimality basis.  The next step is source-level, not solver
+tuning: enumerate QMBCertify's degree-3 basis (words and two-site
+augmentations) at a small `N`, diff it against
+`state_optimality_range`-generated words here, and extend the basis
+construction to match.  No further solver-parameter experiments are
+warranted.

--- a/perf/2604_01555_heisenberg_gap.md
+++ b/perf/2604_01555_heisenberg_gap.md
@@ -213,9 +213,9 @@ retained PSD state-optimality blocks: the smallest eigenvalue was
 This distinguishes the known Mosek numerical sensitivity from a symbolic
 sign or adjoint error in the new constraints.
 
-## 2026-08-14: exact paper configuration (k=10) on a large-memory host
+## 2026-08-14: nominal paper configuration (k=10) on a large-memory host
 
-The exact QMBCertify configuration — `N=100`, 10-site RDM, `linear_psd` state
+The nominal QMBCertify configuration — `N=100`, 10-site RDM, `linear_psd` state
 optimality with separation-5 two-site words, and the axis-permutation
 quotient — was run on a 128-core, ~1 TiB host (`6xa800`) where the model fits.
 Settings: moment-LMI form, Mosek with 32 threads, `1e-8` feasibility and
@@ -244,62 +244,90 @@ still misses the `1e-5` parity target by about 5x.  Mosek terminated with
 `SLOW_PROGRESS` (both primal and dual statuses `FEASIBLE_POINT`, primal and
 dual objectives agreeing to `3.4e-7` absolute), so the remaining gap may be
 numerical stalling rather than model weakness.  A diagnostic rerun with 64
-threads, tolerances relaxed to `1e-7`, and Mosek logging enabled is used to
-distinguish the two; the harness exposes the tolerance through
+threads, tolerances relaxed to `1e-7`, and Mosek logging enabled was
+performed to investigate the two possibilities; its inconclusive result
+is recorded below.  The harness exposes the tolerance through
 `NCTS_MOSEK_TOL` (default `1e-8`).
 
-## 2026-08-14: k=10 gap campaign conclusion — model weakness, not stalling
+### Diagnostic rerun result (64 threads, tol 1e-7; consolidated from PR #375)
 
-The "numerical stalling" hypothesis above is **corrected** by the captured
-Mosek iteration logs (enabled by `NCTS_MOSEK_LOG=1` after PR #376).  Three
-logged runs on `6xa800` settle the question.  All used the moment-LMI form,
+Same model and host; only threads, tolerance, and logging changed.
+
+```text
+RESULT N=100 order=4 rdm=10 state=linear_psd state_range=5 axis_symmetry=true
+objective=-44.3309868524 per_site=-0.4433098685
+objective_bound=-44.3309862053 bound_per_site=-0.4433098621
+status=SLOW_PROGRESS primal=FEASIBLE_POINT dual=FEASIBLE_POINT
+wall=3703.8s max_block=252 n_blocks=214 unique_moments=31485
+```
+
+Wall time was 61.7 minutes at 1607% average CPU; peak RSS was 271.0 GiB
+(`Maximum resident set size: 284155972 kB`).  Mosek's per-iteration log was
+not captured despite `NCTS_MOSEK_LOG=1`.  Compared with the earlier
+32-thread run, the reported bound was 1.86e-5/spin weaker and peak RSS was
+about 26 GiB higher.  With both threads and tolerance changed, these two
+outcomes do not establish monotonic improvement, isolate either parameter's
+effect, or distinguish incomplete convergence from a model mismatch.
+
+## 2026-08-14: k=10 gap campaign evidence — parity remains unresolved
+
+The captured Mosek iteration logs (enabled by `NCTS_MOSEK_LOG=1` after
+PR #376) provide more evidence than the unlogged diagnostic, but do not
+settle whether the separation-5 gap is numerical or structural.  Three
+logged runs on `6xa800` used the moment-LMI form,
 `N=100`, `rdm=10`, `linear_psd` state optimality, axis symmetry, 32 Mosek
 threads, and `1e-8` tolerances.
 
-**Run 1 — separation-5 PSD basis (the paper configuration).**
+In the logs, `PFEAS` and `DFEAS` measure primal and dual feasibility
+residuals, respectively; `MU` is the interior-point complementarity
+measure.  Small objective disagreement alone does not certify feasibility
+or identify the model's true optimum.
+
+**Run 1 — separation-5 PSD basis (the nominal paper configuration).**
 Log: `perf/results/ti_k10_mosek_log_tol1e-8.txt`.  Mosek reached
 `MU = 2.5e-9` with primal and dual objectives agreeing to `3.4e-7` and
-`PFEAS ≈ 5.3e-8` before the `SLOW_PROGRESS` exit.  That is a converged
-solve for practical purposes: `-0.4432912436` per spin is this model's true
-optimum.  The residual `5.34e-5` gap to the paper's `-0.4432378` is therefore
-**model weakness**, not solver stalling.  Peak RSS 209.2 GiB, wall 3369.9 s.
-(An earlier 64-thread, `1e-7` diagnostic of the same model gave a looser
-`-0.4433098621`, consistent with the relaxed tolerance.)
+`PFEAS ≈ 5.3e-8`, `DFEAS ≈ 2.1e-7` before the `SLOW_PROGRESS` exit.
+Both feasibility residuals remained above the requested `1e-8` tolerance.
+The reported bound is `-0.4432912436` per spin, `5.34e-5` below the paper's
+`-0.4432378`, but these diagnostics do not certify that value as the true
+optimum.  Model weakness remains a hypothesis requiring a formulation
+comparison; incomplete numerical convergence has not been excluded.
+Peak RSS 209.2 GiB, solver-harness wall 3369.9 s.
 
 **Run 2 — separation-10 PSD basis (model strengthening attempt).**
 Log: `perf/results/ti_k10_range10_mosek_log.txt`.  The wider two-site words
 grow the model to 170,293 constraints with dense Newton dimension 19,130
-(`3.67e13` flops/factorization; 48,567 unique moments).  Mosek genuinely
-stalls: iterations 19–31 are frozen at `PFEAS 1.1e-6`, `DFEAS 7.6e-5`,
-`MU 1.0e-6`.  Because `DFEAS` never reaches tolerance, the reported
-"bound" `-0.4433962393` is **not a certified lower bound**; the run is
-numerically unusable.  Peak RSS 233.3 GiB, wall 4262.9 s.
+(`3.67e13` flops/factorization; 48,567 unique moments).  Progress becomes
+negligible late in the solve, ending at `PFEAS 1.1e-6`, `DFEAS 7.6e-5`,
+`MU 1.0e-6` with `SLOW_PROGRESS`.  The reported bound `-0.4433962393`
+is **not certified by this run** and cannot establish the strengthened
+model's optimum.  Peak RSS 233.3 GiB, solver-harness wall 4262.9 s.
 
 **Run 3 — separation-10 with `NCTS_MOSEK_SOLVE_FORM=dual`.**
-Log: `perf/results/ti_k10_range10_dualform_mosek_log.txt`.  Mosek **ignored
-the solve-form hint**: the log reports `Optimizer - solved problem: the
-primal` (Mosek solves the primal for problems containing semidefinite
-variables), and the iteration trajectory is identical to Run 2, including
-the frozen stall and the same final values.  Peak RSS 224.1 GiB, wall
-3760.3 s.  The conditioning knob has no effect on this problem class.
+Log: `perf/results/ti_k10_range10_dualform_mosek_log.txt`.  Despite the
+solve-form hint, the log still reports `Optimizer - solved problem: the
+primal`.  The printed numerical iterates and final values match Run 2;
+iteration timings differ.  Peak RSS 224.1 GiB, solver-harness wall
+3760.3 s.  This option did not improve convergence in the tested model.
 
-| configuration | bound / spin | vs paper `-0.4432378` | solver state |
+| configuration | reported bound / spin | vs paper `-0.4432378` | solver state |
 |:--|--:|--:|:--|
 | paper SDP New (k=10, sep 5) | -0.4432378 | — | — |
-| k=10, sep 5 (Run 1) | -0.4432912436 | 5.34e-5 | converged (MU 2.5e-9) |
-| k=10, sep 5, 64t/1e-7 | -0.4433098621 | 7.21e-5 | relaxed tolerance |
-| k=10, sep 10 primal (Run 2) | -0.4433962393 | 1.58e-4 | stalled, uncertified |
-| k=10, sep 10 "dual" (Run 3) | -0.4433962393 | 1.58e-4 | identical stall |
+| k=10, sep 5 (Run 1) | -0.4432912436 | 5.34e-5 | SLOW_PROGRESS; feasibility above tolerance |
+| k=10, sep 5, 64t/1e-7 | -0.4433098621 | 7.21e-5 | SLOW_PROGRESS; no iteration log |
+| k=10, sep 10 primal (Run 2) | -0.4433962393 | 1.58e-4 | SLOW_PROGRESS; uncertified |
+| k=10, sep 10 "dual" (Run 3) | -0.4433962393 | 1.58e-4 | SLOW_PROGRESS; same numerical iterates |
 
-**Verdict: parity not achieved with existing knobs.**  The separation-5
-model converges but is structurally `5.34e-5` weaker than QMBCertify's
-published bound; the separation-10 model is too ill-conditioned for Mosek
-to solve at all.  Since the mechanisms (10-site RDM, linear commutators,
+The wall times above are the `RESULT wall` measurements inside the harness;
+the enclosing process timings in the logs also include startup overhead.
+
+**Verdict: parity was not demonstrated by these runs.**  Neither a true
+structural gap nor impossibility of convergence with other solver settings
+has been established.  The mechanisms (10-site RDM, linear commutators,
 degree-3 PSD state optimality, axis quotient) nominally match the paper,
-the discrepancy most likely lives in the exact contents of the degree-3
-PSD state-optimality basis.  The next step is source-level, not solver
-tuning: enumerate QMBCertify's degree-3 basis (words and two-site
-augmentations) at a small `N`, diff it against
-`state_optimality_range`-generated words here, and extend the basis
-construction to match.  No further solver-parameter experiments are
-warranted.
+so a useful next investigation is to enumerate QMBCertify's degree-3 basis
+(words and two-site augmentations) at a small `N` and compare it with
+`state_optimality_range`-generated words here.  Any discovered differences
+should be checked for mathematical equivalence before changing the model.
+A converged solve with checked feasibility or an independently validated
+certificate is still needed to resolve the numerical uncertainty.

--- a/perf/results/ti_k10_mosek_log_tol1e-8.txt
+++ b/perf/results/ti_k10_mosek_log_tol1e-8.txt
@@ -1,0 +1,103 @@
+threads=32 cpu_threads=128 tol=1e-8 solve_form=free scaling=free presolve=free dualize=false ns=[100] rdm=10 state=linear_psd state_range=5 axis_symmetry=true
+Problem
+  Name                   :                 
+  Objective sense        : minimize        
+  Type                   : CONIC (conic optimization problem)
+  Constraints            : 4035            
+  Affine conic cons.     : 214 (129797 rows)
+  Disjunctive cons.      : 0               
+  Cones                  : 0               
+  Scalar variables       : 31485           
+  Matrix variables       : 0               
+  Integer variables      : 0               
+
+Optimizer started.
+Presolve started.
+Linear dependency checker started.
+Linear dependency checker terminated.
+Eliminator started.
+Freed constraints in eliminator : 0
+Eliminator terminated.
+Eliminator started.
+Freed constraints in eliminator : 0
+Eliminator terminated.
+Eliminator - tries                  : 2                 time                   : 0.00            
+Lin. dep.  - tries                  : 1                 time                   : 0.09            
+Lin. dep.  - primal attempts        : 1                 successes              : 1               
+Lin. dep.  - dual attempts          : 0                 successes              : 0               
+Lin. dep.  - primal deps.           : 0                 dual deps.             : 0               
+Presolve terminated. Time: 2.36    
+Optimizer  - threads                : 32              
+Optimizer  - solved problem         : the primal      
+Optimizer  - Constraints            : 133831          
+Optimizer  - Cones                  : 1               
+Optimizer  - Scalar variables       : 25473             conic                  : 25472           
+Optimizer  - Semi-definite variables: 213               scalarized             : 129796          
+Factor     - setup time             : 317.77          
+Factor     - dense det. time        : 90.72             GP order time          : 2.03            
+Factor     - nonzeros before factor : 8.23e+08          after factor           : 1.54e+09        
+Factor     - dense dim.             : 16155             flops                  : 3.41e+13        
+Factor     - GP saved nzs           : 1.47e+08          GP saved flops         : 5.03e+12        
+ITE PFEAS    DFEAS    GFEAS    PRSTATUS   POBJ              DOBJ              MU       TIME  
+0   1.0e+00  7.5e+01  1.0e+00  0.00e+00   0.000000000e+00   0.000000000e+00   1.0e+00  322.93
+1   4.4e-01  3.3e+01  3.6e-01  5.08e-01   -7.827150584e+00  -7.718183831e+00  4.4e-01  386.82
+2   3.0e-01  2.3e+01  2.6e-01  1.65e-01   -1.272667615e+01  -1.250724761e+01  3.0e-01  446.88
+3   1.7e-01  1.3e+01  1.4e-01  2.17e-01   -1.986136550e+01  -1.960644784e+01  1.7e-01  507.15
+4   1.1e-01  8.3e+00  7.7e-02  3.58e-01   -2.519748994e+01  -2.498023645e+01  1.1e-01  564.39
+5   3.4e-02  2.5e+00  1.4e-02  5.63e-01   -3.528524272e+01  -3.520098111e+01  3.4e-02  623.72
+6   2.2e-02  1.6e+00  7.2e-03  1.01e+00   -3.786949155e+01  -3.781699767e+01  2.2e-02  681.36
+7   4.6e-03  3.4e-01  5.9e-04  1.10e+00   -4.178428309e+01  -4.177863170e+01  4.6e-03  743.64
+8   1.0e-03  7.7e-02  5.6e-05  1.35e+00   -4.292139976e+01  -4.292047710e+01  1.0e-03  862.83
+9   3.0e-04  2.3e-02  8.3e-06  1.29e+00   -4.334182132e+01  -4.334157184e+01  3.0e-04  929.34
+10  1.6e-04  1.2e-02  3.1e-06  1.15e+00   -4.396449514e+01  -4.396436072e+01  1.6e-04  989.78
+11  1.2e-04  8.9e-03  2.1e-06  1.05e+00   -4.417516752e+01  -4.417506270e+01  1.2e-04  1114.40
+12  1.1e-04  8.1e-03  1.8e-06  1.05e+00   -4.420307173e+01  -4.420297732e+01  1.1e-04  1173.20
+13  8.7e-05  6.5e-03  1.3e-06  1.07e+00   -4.423306161e+01  -4.423298657e+01  8.7e-05  1233.44
+14  6.4e-05  4.8e-03  7.9e-07  1.08e+00   -4.424742370e+01  -4.424737113e+01  6.4e-05  1292.10
+15  3.1e-05  2.3e-03  2.7e-07  1.08e+00   -4.429749302e+01  -4.429746773e+01  3.1e-05  1352.05
+16  8.2e-06  6.1e-04  3.5e-08  1.06e+00   -4.432827906e+01  -4.432827311e+01  8.2e-06  1422.93
+17  4.8e-06  3.6e-04  1.6e-08  1.02e+00   -4.433341777e+01  -4.433341416e+01  4.8e-06  1481.68
+18  1.2e-06  5.8e-05  1.1e-09  9.61e-01   -4.434036712e+01  -4.434036623e+01  8.6e-07  1552.38
+19  1.1e-06  3.8e-05  6.6e-10  6.86e-01   -4.434063139e+01  -4.434063061e+01  5.5e-07  1667.60
+20  7.0e-07  8.3e-06  1.1e-10  5.53e-01   -4.434114257e+01  -4.434114189e+01  1.5e-07  1748.74
+21  4.2e-07  4.5e-06  6.6e-11  -1.16e-01  -4.434082942e+01  -4.434082844e+01  7.2e-08  1834.90
+22  3.6e-07  3.7e-06  5.7e-11  -2.91e-01  -4.434056474e+01  -4.434056366e+01  5.8e-08  1897.94
+23  2.4e-07  2.5e-06  4.3e-11  -3.95e-01  -4.433993116e+01  -4.433992975e+01  3.6e-08  1965.76
+24  1.9e-07  1.9e-06  3.4e-11  -3.90e-01  -4.433906951e+01  -4.433906796e+01  2.7e-08  2038.61
+25  1.8e-07  1.6e-06  2.8e-11  -3.09e-01  -4.433820178e+01  -4.433820018e+01  2.1e-08  2108.21
+26  1.4e-07  9.6e-07  1.6e-11  -1.36e-01  -4.433547432e+01  -4.433547292e+01  1.2e-08  2171.66
+27  1.2e-07  7.1e-07  1.0e-11  3.23e-01   -4.433358143e+01  -4.433358036e+01  8.9e-09  2233.56
+28  1.0e-07  5.6e-07  7.4e-12  5.46e-01   -4.433236704e+01  -4.433236616e+01  7.0e-09  2317.30
+29  6.2e-08  2.8e-07  2.6e-12  6.63e-01   -4.432980017e+01  -4.432979971e+01  3.4e-09  2398.32
+30  5.7e-08  2.4e-07  2.1e-12  8.56e-01   -4.432944546e+01  -4.432944506e+01  2.9e-09  2518.91
+31  5.3e-08  2.1e-07  1.7e-12  8.80e-01   -4.432914216e+01  -4.432914182e+01  2.5e-09  2582.56
+32  5.3e-08  2.1e-07  1.7e-12  8.93e-01   -4.432912470e+01  -4.432912436e+01  2.5e-09  2648.68
+33  5.3e-08  2.1e-07  1.7e-12  8.93e-01   -4.432912470e+01  -4.432912436e+01  2.5e-09  2729.26
+34  5.3e-08  2.1e-07  1.7e-12  8.93e-01   -4.432912470e+01  -4.432912436e+01  2.5e-09  2816.91
+Optimizer terminated. Time: 2889.80 
+
+RESULT N=100 order=4 rdm=10 state=linear_psd state_range=5 axis_symmetry=true objective=-44.3291247035 per_site=-0.4432912470 objective_bound=-44.3291243612 bound_per_site=-0.4432912436 status=SLOW_PROGRESS primal=FEASIBLE_POINT dual=FEASIBLE_POINT wall=3369.9s max_block=252 n_blocks=214 unique_moments=31485
+done=2026-08-14T04:42:32.274
+	Command being timed: "/home/yushengzhao/.juliaup/bin/julia perf/ti_mosek_run.jl"
+	User time (seconds): 34749.13
+	System time (seconds): 765.23
+	Percent of CPU this job got: 1012%
+	Elapsed (wall clock) time (h:mm:ss or m:ss): 58:28.19
+	Average shared text size (kbytes): 0
+	Average unshared data size (kbytes): 0
+	Average stack size (kbytes): 0
+	Average total size (kbytes): 0
+	Maximum resident set size (kbytes): 219378072
+	Average resident set size (kbytes): 0
+	Major (requiring I/O) page faults: 4899
+	Minor (reclaiming a frame) page faults: 47763496
+	Voluntary context switches: 6858903
+	Involuntary context switches: 219232
+	Swaps: 0
+	File system inputs: 731928
+	File system outputs: 25296
+	Socket messages sent: 0
+	Socket messages received: 0
+	Signals delivered: 0
+	Page size (bytes): 4096
+	Exit status: 0

--- a/perf/results/ti_k10_range10_dualform_mosek_log.txt
+++ b/perf/results/ti_k10_range10_dualform_mosek_log.txt
@@ -1,0 +1,109 @@
+  Activating project at `~/projects/nctssos-run`
+  Activating project at `~/.nctssos_ti_mosek_env`
+   Resolving package versions...
+     Project No packages added to or removed from `~/.nctssos_ti_mosek_env/Project.toml`
+    Manifest No packages added to or removed from `~/.nctssos_ti_mosek_env/Manifest.toml`
+   Resolving package versions...
+     Project No packages added to or removed from `~/.nctssos_ti_mosek_env/Project.toml`
+    Manifest No packages added to or removed from `~/.nctssos_ti_mosek_env/Manifest.toml`
+host=6xa800 julia=1.12.6 started=2026-08-14T06:24:18.182
+threads=32 cpu_threads=128 tol=1e-8 solve_form=dual scaling=free presolve=free dualize=false ns=[100] rdm=10 state=linear_psd state_range=10 axis_symmetry=true
+Problem
+  Name                   :                 
+  Objective sense        : minimize        
+  Type                   : CONIC (conic optimization problem)
+  Constraints            : 6487            
+  Affine conic cons.     : 214 (163807 rows)
+  Disjunctive cons.      : 0               
+  Cones                  : 0               
+  Scalar variables       : 48567           
+  Matrix variables       : 0               
+  Integer variables      : 0               
+
+Optimizer started.
+Presolve started.
+Linear dependency checker started.
+Linear dependency checker terminated.
+Eliminator started.
+Freed constraints in eliminator : 0
+Eliminator terminated.
+Eliminator started.
+Freed constraints in eliminator : 0
+Eliminator terminated.
+Eliminator - tries                  : 2                 time                   : 0.00            
+Lin. dep.  - tries                  : 1                 time                   : 0.12            
+Lin. dep.  - primal attempts        : 1                 successes              : 1               
+Lin. dep.  - dual attempts          : 0                 successes              : 0               
+Lin. dep.  - primal deps.           : 0                 dual deps.             : 0               
+Presolve terminated. Time: 3.57    
+Optimizer  - threads                : 32              
+Optimizer  - solved problem         : the primal      
+Optimizer  - Constraints            : 170293          
+Optimizer  - Cones                  : 1               
+Optimizer  - Scalar variables       : 35690             conic                  : 35689           
+Optimizer  - Semi-definite variables: 213               scalarized             : 163806          
+Factor     - setup time             : 369.87          
+Factor     - dense det. time        : 135.02            GP order time          : 8.94            
+Factor     - nonzeros before factor : 8.49e+08          after factor           : 1.69e+09        
+Factor     - dense dim.             : 19130             flops                  : 3.67e+13        
+Factor     - GP saved nzs           : 2.09e+08          GP saved flops         : 6.78e+12        
+ITE PFEAS    DFEAS    GFEAS    PRSTATUS   POBJ              DOBJ              MU       TIME  
+0   1.0e+00  7.5e+01  1.0e+00  0.00e+00   0.000000000e+00   0.000000000e+00   1.0e+00  376.78
+1   4.6e-01  3.5e+01  3.4e-01  4.94e-01   -7.352117439e+00  -7.335066835e+00  4.6e-01  449.89
+2   3.4e-01  2.5e+01  2.7e-01  1.42e-01   -1.149639547e+01  -1.137629890e+01  3.4e-01  519.34
+3   1.8e-01  1.4e+01  1.4e-01  1.70e-01   -1.900561796e+01  -1.880787940e+01  1.8e-01  590.82
+4   1.2e-01  9.0e+00  8.2e-02  2.94e-01   -2.420844605e+01  -2.402078734e+01  1.2e-01  666.57
+5   5.2e-02  3.9e+00  2.6e-02  4.93e-01   -3.248314457e+01  -3.237024519e+01  5.2e-02  741.88
+6   8.8e-03  6.6e-01  1.8e-03  8.57e-01   -4.046537625e+01  -4.044843591e+01  8.8e-03  816.64
+7   2.8e-03  2.1e-01  2.9e-04  1.21e+00   -4.236750659e+01  -4.236295606e+01  2.8e-03  951.20
+8   6.4e-04  4.8e-02  2.9e-05  1.25e+00   -4.313064650e+01  -4.312983694e+01  6.4e-04  1021.99
+9   2.2e-04  1.7e-02  5.7e-06  1.22e+00   -4.344176719e+01  -4.344151744e+01  2.2e-04  1094.64
+10  1.3e-04  1.0e-02  2.6e-06  1.12e+00   -4.382494014e+01  -4.382478403e+01  1.3e-04  1159.77
+11  9.8e-05  7.4e-03  1.7e-06  1.05e+00   -4.410122195e+01  -4.410110299e+01  9.8e-05  1292.81
+12  7.0e-05  5.2e-03  1.0e-06  1.04e+00   -4.425613035e+01  -4.425604564e+01  7.0e-05  1372.16
+13  6.6e-05  5.0e-03  9.2e-07  1.05e+00   -4.424842362e+01  -4.424834420e+01  6.6e-05  1438.46
+14  5.7e-05  4.3e-03  7.3e-07  1.05e+00   -4.424697190e+01  -4.424690519e+01  5.7e-05  1506.45
+15  2.7e-05  2.0e-03  2.4e-07  1.06e+00   -4.429842263e+01  -4.429839075e+01  2.7e-05  1581.30
+16  8.0e-06  6.0e-04  3.8e-08  1.05e+00   -4.432688526e+01  -4.432687626e+01  8.0e-06  1649.47
+17  2.2e-06  1.6e-04  5.4e-09  1.02e+00   -4.433635646e+01  -4.433635402e+01  2.2e-06  1717.87
+18  1.2e-06  7.9e-05  1.9e-09  9.51e-01   -4.433953503e+01  -4.433953372e+01  1.1e-06  1855.71
+19  1.2e-06  7.9e-05  1.9e-09  9.51e-01   -4.433953503e+01  -4.433953372e+01  1.1e-06  1933.52
+20  1.2e-06  7.7e-05  1.8e-09  9.36e-01   -4.433958446e+01  -4.433958318e+01  1.0e-06  2002.52
+21  1.1e-06  7.7e-05  1.8e-09  9.37e-01   -4.433960841e+01  -4.433960714e+01  1.0e-06  2073.43
+22  1.1e-06  7.6e-05  1.8e-09  9.37e-01   -4.433962020e+01  -4.433961894e+01  1.0e-06  2141.04
+23  1.1e-06  7.6e-05  1.8e-09  9.37e-01   -4.433962313e+01  -4.433962186e+01  1.0e-06  2209.96
+24  1.1e-06  7.6e-05  1.8e-09  9.37e-01   -4.433962459e+01  -4.433962332e+01  1.0e-06  2277.83
+25  1.1e-06  7.6e-05  1.8e-09  9.37e-01   -4.433962495e+01  -4.433962369e+01  1.0e-06  2347.85
+26  1.1e-06  7.6e-05  1.8e-09  9.37e-01   -4.433962513e+01  -4.433962387e+01  1.0e-06  2415.27
+27  1.1e-06  7.6e-05  1.8e-09  9.37e-01   -4.433962518e+01  -4.433962392e+01  1.0e-06  2484.88
+28  1.1e-06  7.6e-05  1.8e-09  9.37e-01   -4.433962519e+01  -4.433962393e+01  1.0e-06  2552.81
+29  1.1e-06  7.6e-05  1.8e-09  9.37e-01   -4.433962519e+01  -4.433962393e+01  1.0e-06  2622.57
+30  1.1e-06  7.6e-05  1.8e-09  9.37e-01   -4.433962520e+01  -4.433962393e+01  1.0e-06  2700.00
+31  1.1e-06  7.6e-05  1.8e-09  9.37e-01   -4.433962520e+01  -4.433962393e+01  1.0e-06  2819.15
+Optimizer terminated. Time: 2920.98 
+
+RESULT N=100 order=4 rdm=10 state=linear_psd state_range=10 axis_symmetry=true objective=-44.3396251951 per_site=-0.4433962520 objective_bound=-44.3396239321 bound_per_site=-0.4433962393 status=SLOW_PROGRESS primal=FEASIBLE_POINT dual=FEASIBLE_POINT wall=3760.3s max_block=252 n_blocks=214 unique_moments=48567
+done=2026-08-14T07:27:15.332
+	Command being timed: "/home/yushengzhao/.juliaup/bin/julia perf/ti_mosek_run.jl"
+	User time (seconds): 34540.89
+	System time (seconds): 835.18
+	Percent of CPU this job got: 920%
+	Elapsed (wall clock) time (h:mm:ss or m:ss): 1:04:01
+	Average shared text size (kbytes): 0
+	Average unshared data size (kbytes): 0
+	Average stack size (kbytes): 0
+	Average total size (kbytes): 0
+	Maximum resident set size (kbytes): 234991208
+	Average resident set size (kbytes): 0
+	Major (requiring I/O) page faults: 3562
+	Minor (reclaiming a frame) page faults: 57965699
+	Voluntary context switches: 6945529
+	Involuntary context switches: 1117641
+	Swaps: 0
+	File system inputs: 273144
+	File system outputs: 776
+	Socket messages sent: 0
+	Socket messages received: 0
+	Signals delivered: 0
+	Page size (bytes): 4096
+	Exit status: 0

--- a/perf/results/ti_k10_range10_mosek_log.txt
+++ b/perf/results/ti_k10_range10_mosek_log.txt
@@ -1,0 +1,100 @@
+threads=32 cpu_threads=128 tol=1e-8 solve_form=free scaling=free presolve=free dualize=false ns=[100] rdm=10 state=linear_psd state_range=10 axis_symmetry=true
+Problem
+  Name                   :                 
+  Objective sense        : minimize        
+  Type                   : CONIC (conic optimization problem)
+  Constraints            : 6487            
+  Affine conic cons.     : 214 (163807 rows)
+  Disjunctive cons.      : 0               
+  Cones                  : 0               
+  Scalar variables       : 48567           
+  Matrix variables       : 0               
+  Integer variables      : 0               
+
+Optimizer started.
+Presolve started.
+Linear dependency checker started.
+Linear dependency checker terminated.
+Eliminator started.
+Freed constraints in eliminator : 0
+Eliminator terminated.
+Eliminator started.
+Freed constraints in eliminator : 0
+Eliminator terminated.
+Eliminator - tries                  : 2                 time                   : 0.00            
+Lin. dep.  - tries                  : 1                 time                   : 0.12            
+Lin. dep.  - primal attempts        : 1                 successes              : 1               
+Lin. dep.  - dual attempts          : 0                 successes              : 0               
+Lin. dep.  - primal deps.           : 0                 dual deps.             : 0               
+Presolve terminated. Time: 3.48    
+Optimizer  - threads                : 32              
+Optimizer  - solved problem         : the primal      
+Optimizer  - Constraints            : 170293          
+Optimizer  - Cones                  : 1               
+Optimizer  - Scalar variables       : 35690             conic                  : 35689           
+Optimizer  - Semi-definite variables: 213               scalarized             : 163806          
+Factor     - setup time             : 385.99          
+Factor     - dense det. time        : 149.74            GP order time          : 8.99            
+Factor     - nonzeros before factor : 8.49e+08          after factor           : 1.69e+09        
+Factor     - dense dim.             : 19130             flops                  : 3.67e+13        
+Factor     - GP saved nzs           : 2.09e+08          GP saved flops         : 6.78e+12        
+ITE PFEAS    DFEAS    GFEAS    PRSTATUS   POBJ              DOBJ              MU       TIME  
+0   1.0e+00  7.5e+01  1.0e+00  0.00e+00   0.000000000e+00   0.000000000e+00   1.0e+00  392.68
+1   4.6e-01  3.5e+01  3.4e-01  4.94e-01   -7.352117439e+00  -7.335066835e+00  4.6e-01  464.58
+2   3.4e-01  2.5e+01  2.7e-01  1.42e-01   -1.149639547e+01  -1.137629890e+01  3.4e-01  540.46
+3   1.8e-01  1.4e+01  1.4e-01  1.70e-01   -1.900561796e+01  -1.880787940e+01  1.8e-01  612.25
+4   1.2e-01  9.0e+00  8.2e-02  2.94e-01   -2.420844605e+01  -2.402078734e+01  1.2e-01  690.40
+5   5.2e-02  3.9e+00  2.6e-02  4.93e-01   -3.248314457e+01  -3.237024519e+01  5.2e-02  759.46
+6   8.8e-03  6.6e-01  1.8e-03  8.57e-01   -4.046537625e+01  -4.044843591e+01  8.8e-03  835.37
+7   2.8e-03  2.1e-01  2.9e-04  1.21e+00   -4.236750659e+01  -4.236295606e+01  2.8e-03  990.29
+8   6.4e-04  4.8e-02  2.9e-05  1.25e+00   -4.313064650e+01  -4.312983694e+01  6.4e-04  1069.12
+9   2.2e-04  1.7e-02  5.7e-06  1.22e+00   -4.344176719e+01  -4.344151744e+01  2.2e-04  1147.26
+10  1.3e-04  1.0e-02  2.6e-06  1.12e+00   -4.382494014e+01  -4.382478403e+01  1.3e-04  1227.14
+11  9.8e-05  7.4e-03  1.7e-06  1.05e+00   -4.410122195e+01  -4.410110299e+01  9.8e-05  1374.22
+12  7.0e-05  5.2e-03  1.0e-06  1.04e+00   -4.425613035e+01  -4.425604564e+01  7.0e-05  1450.39
+13  6.6e-05  5.0e-03  9.2e-07  1.05e+00   -4.424842362e+01  -4.424834420e+01  6.6e-05  1522.82
+14  5.7e-05  4.3e-03  7.3e-07  1.05e+00   -4.424697190e+01  -4.424690519e+01  5.7e-05  1594.54
+15  2.7e-05  2.0e-03  2.4e-07  1.06e+00   -4.429842263e+01  -4.429839075e+01  2.7e-05  1667.83
+16  8.0e-06  6.0e-04  3.8e-08  1.05e+00   -4.432688526e+01  -4.432687626e+01  8.0e-06  1745.25
+17  2.2e-06  1.6e-04  5.4e-09  1.02e+00   -4.433635646e+01  -4.433635402e+01  2.2e-06  1822.01
+18  1.2e-06  7.9e-05  1.9e-09  9.51e-01   -4.433953503e+01  -4.433953372e+01  1.1e-06  1960.30
+19  1.2e-06  7.9e-05  1.9e-09  9.51e-01   -4.433953503e+01  -4.433953372e+01  1.1e-06  2038.61
+20  1.2e-06  7.7e-05  1.8e-09  9.36e-01   -4.433958446e+01  -4.433958318e+01  1.0e-06  2116.78
+21  1.1e-06  7.7e-05  1.8e-09  9.37e-01   -4.433960841e+01  -4.433960714e+01  1.0e-06  2223.30
+22  1.1e-06  7.6e-05  1.8e-09  9.37e-01   -4.433962020e+01  -4.433961894e+01  1.0e-06  2367.14
+23  1.1e-06  7.6e-05  1.8e-09  9.37e-01   -4.433962313e+01  -4.433962186e+01  1.0e-06  2486.08
+24  1.1e-06  7.6e-05  1.8e-09  9.37e-01   -4.433962459e+01  -4.433962332e+01  1.0e-06  2620.62
+25  1.1e-06  7.6e-05  1.8e-09  9.37e-01   -4.433962495e+01  -4.433962369e+01  1.0e-06  2727.09
+26  1.1e-06  7.6e-05  1.8e-09  9.37e-01   -4.433962513e+01  -4.433962387e+01  1.0e-06  2850.68
+27  1.1e-06  7.6e-05  1.8e-09  9.37e-01   -4.433962518e+01  -4.433962392e+01  1.0e-06  2921.44
+28  1.1e-06  7.6e-05  1.8e-09  9.37e-01   -4.433962519e+01  -4.433962393e+01  1.0e-06  3044.46
+29  1.1e-06  7.6e-05  1.8e-09  9.37e-01   -4.433962519e+01  -4.433962393e+01  1.0e-06  3156.48
+30  1.1e-06  7.6e-05  1.8e-09  9.37e-01   -4.433962520e+01  -4.433962393e+01  1.0e-06  3248.55
+31  1.1e-06  7.6e-05  1.8e-09  9.37e-01   -4.433962520e+01  -4.433962393e+01  1.0e-06  3351.51
+Optimizer terminated. Time: 3423.22 
+
+RESULT N=100 order=4 rdm=10 state=linear_psd state_range=10 axis_symmetry=true objective=-44.3396251951 per_site=-0.4433962520 objective_bound=-44.3396239321 bound_per_site=-0.4433962393 status=SLOW_PROGRESS primal=FEASIBLE_POINT dual=FEASIBLE_POINT wall=4262.9s max_block=252 n_blocks=214 unique_moments=48567
+done=2026-08-14T06:10:03.644
+	Command being timed: "/home/yushengzhao/.juliaup/bin/julia perf/ti_mosek_run.jl"
+	User time (seconds): 35209.38
+	System time (seconds): 1330.33
+	Percent of CPU this job got: 848%
+	Elapsed (wall clock) time (h:mm:ss or m:ss): 1:11:47
+	Average shared text size (kbytes): 0
+	Average unshared data size (kbytes): 0
+	Average stack size (kbytes): 0
+	Average total size (kbytes): 0
+	Maximum resident set size (kbytes): 244666632
+	Average resident set size (kbytes): 0
+	Major (requiring I/O) page faults: 2514
+	Minor (reclaiming a frame) page faults: 58158881
+	Voluntary context switches: 7549799
+	Involuntary context switches: 2270070
+	Swaps: 0
+	File system inputs: 239208
+	File system outputs: 776
+	Socket messages sent: 0
+	Socket messages received: 0
+	Signals delivered: 0
+	Page size (bytes): 4096
+	Exit status: 0


### PR DESCRIPTION
## Purpose

Records the N=100, k=10 TI Heisenberg campaign against arXiv:2604.01555 (paper target -0.4432378/spin, 1e-5 comparison threshold), with three captured Mosek logs. Consolidates the unique diagnostic measurements from #375 so that PR can be closed without losing its result, runtime, or memory data. No source changes.

## Findings and limitations

- The separation-5 run reports -0.4432912436/spin, but exits with SLOW_PROGRESS. PFEAS ≈ 5.3e-8 and DFEAS ≈ 2.1e-7 remain above the requested 1e-8 tolerance. Close primal/dual objectives do not establish the true optimum or prove model weakness.
- The separation-10 runs stall and report -0.4433962393/spin; this is not a certified lower bound from these runs.
- Setting NCTS_MOSEK_SOLVE_FORM=dual produces the same printed numerical iterates and final values as the default in this tested model, with different timings.
- Parity remains unresolved. A small-N formulation/basis comparison is a useful next investigation; numerical uncertainty still requires checked feasibility or an independently validated certificate.

## Validation

- Cross-checked all three logs against the reported bounds, wall times, peak RSS, statuses, and final residuals.
- Confirmed the two range-10 logs have identical printed numerical iterates apart from timing.
- Confirmed the complete #375 diagnostic RESULT block is retained.
- Parent correction passes git diff --check. Raw solver logs intentionally retain their original whitespace.
- Fresh independent review completed; corrected the remaining stale diagnostic wording. CI will be checked on the revised head before merge.

## Risk

Evidence/documentation only. These results must not be treated as a numerical certificate or proof of structural model weakness. No expensive campaign runs were repeated for this revision.
