### PR TITLE
perf(setup): expose Julia precompile timing

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -57,9 +57,15 @@ if [[ -n "${MOSEK_LICENSE_B64:-}" || -n "${MOSEK_LICENSE:-}" ]]; then
 fi
 
 echo "==> Instantiating and precompiling the package environment"
-SECONDS=0
-"$julia_bin" --project="$repo_root" -e 'using Pkg; Pkg.instantiate(); Pkg.precompile()'
-echo "==> Package environment ready in ${SECONDS}s"
+"$julia_bin" --startup-file=no --project="$repo_root" -e '
+    using Pkg
+
+    elapsed = @elapsed Pkg.instantiate(; allow_autoprecomp=false)
+    println("==> Package environment instantiated in $(round(elapsed; digits=1))s")
+
+    elapsed = @elapsed Pkg.precompile()
+    println("==> Package environment precompiled in $(round(elapsed; digits=1))s")
+'
 
 # The docs environment includes large optional dependencies (including CairoMakie and Yao),
 # so it is intentionally left on demand. Run `make init-docs` before docs work.


### PR DESCRIPTION
## Summary

- prevent `Pkg.instantiate` from implicitly starting precompilation before its timing can be reported
- report dependency instantiation and precompilation durations separately
- disable user startup files during package setup to avoid unrelated startup overhead

Cold-orb investigation found that package precompilation accounted for 121 seconds of the 139-second setup run. The warm setup path remains about 1.8 seconds. Eager precompilation is retained so Amp project snapshots can reuse the compiled cache.

Amp thread: https://ampcode.com/threads/T-01a099bc-1d1c-7323-9ef6-f1c46592ec56

## How to test

- `bash -n .agents/setup .agents/resume`
- run `.agents/setup` twice and confirm separate instantiate/precompile timings and idempotent warm runs
- verify Julia from a clean non-interactive login shell